### PR TITLE
ATLAS-35 Upgrade terraform and introduce github action (#12)

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,19 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - perbernhardt
+  - thomasstoermer
+  - maikschwan
+  - romansaul
+  - dan-leanix
+  - kaibepperling
+  - anuleanix

--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,0 +1,10 @@
+name: 'Auto Assign'
+on: pull_request
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.1.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+name: docker-terragrunt
+
+on:
+  repository_dispatch:
+    types: [trigger-docker-terragrunt]
+  push:
+    paths-ignore:
+      - '**README.md'
+
+env:
+  ACTION_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+jobs:
+  main:
+    name: docker-terragrunt-${{ github.run_number }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get credentials
+        uses: leanix/secrets-action@master
+        with:
+          secret-store-credentials: ${{ secrets.INJECTED_SECRET_STORE_CREDENTIALS }}
+
+      - name: Build and push image
+        id: build-image
+        uses: leanix/release-docker-image-action@master
+        with:
+          name: leanix/terragrunt
+
+      - name: Send build fail message
+        if: failure()
+        uses: archive/github-actions-slack@v1.0.0
+        with:
+          slack-bot-user-oauth-access-token: ${{ env.SLACK_TOKEN }}
+          slack-channel: '#team-atlas-notifications'
+          slack-text: |
+            :thumbsdown: ${{ github.repository }} could not be build in the next version ${{ steps.build-image.outputs.tag }}
+            ${{ env.ACTION_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM golang:1.13.1-alpine
+FROM python:3.9.0-buster
 
-ENV TERRAFORM_VERSION=0.12.18
-ENV TERRAGRUNT_VERSION=0.21.9
-ENV ISTIO_VERSION=1.4.2
+ENV TERRAFORM_VERSION=0.13.4
+ENV TERRAGRUNT_VERSION=0.25.2
 
-RUN apk add --update git bash openssh openssl curl build-base py-pip python-dev libffi-dev libressl-dev && \
-    pip --no-cache-dir install -U pip && \
-    pip --no-cache-dir install azure-cli && \
+RUN pip --no-cache-dir install azure-cli && \
     az aks install-cli
 
 RUN cd /tmp && \
@@ -18,12 +15,6 @@ RUN cd /tmp && \
 
 RUN curl -Lo /usr/local/bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && \
     chmod a+x /usr/local/bin/terragrunt
-
-RUN curl -Lo istioctl.tar.gz https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-linux.tar.gz && \
-    tar -zxvf istioctl.tar.gz && \
-    mv istio-${ISTIO_VERSION}/bin/istioctl /usr/local/bin/istioctl && \
-    rm -r istioctl.tar.gz istio-${ISTIO_VERSION} && \
-    chmod a+x /usr/local/bin/istioctl
 
 RUN mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 


### PR DESCRIPTION
@maikschwan @perbernhardt We should merge this to master as well, because our iac-action is based on the 0.13.4 image.

* ATLAS-35 Workflow to build and push images

* ATLAS-35 Notify about failure from all branches

* ATLAS-35 Change notification channel

* ATLAS-35 Change base image to python

* ATLAS-35 Remove istio

* ATLAS-35 Update terraform and terragrunt

* ATLAS-35 Add second workflow to test docker issue

* ATLAS-35 Fix docker image name

* ATLAS-35 Add auto assign workflow